### PR TITLE
fix to work with properties that have _at in the name

### DIFF
--- a/lib/boolean_timestamps.rb
+++ b/lib/boolean_timestamps.rb
@@ -8,7 +8,7 @@ module BooleanTimestamps
   class_methods do
     def boolean_timestamps(*attributes)
       attributes.each do |timestamp_attribute|
-        boolean_attribute = timestamp_attribute.to_s.gsub('_at', '')
+        boolean_attribute = timestamp_attribute.to_s.gsub(/_at\z/, '')
         define_method boolean_attribute do
           send("#{timestamp_attribute}?")
         end

--- a/spec/boolean_timestamps_spec.rb
+++ b/spec/boolean_timestamps_spec.rb
@@ -5,6 +5,10 @@ describe BooleanTimestamps do
     boolean_timestamps :activated_at
   end
 
+  class War < ActiveRecord::Base
+    boolean_timestamps :massive_attack_at
+  end
+
   it 'has a version number' do
     expect(BooleanTimestamps::VERSION).not_to be nil
   end
@@ -28,6 +32,11 @@ describe BooleanTimestamps do
       user = User.new(activated_at: DateTime.new)
       user.activated = false
       expect(user.activated_at).to be_nil
+    end
+    it 'works with properties that have _at in them' do
+      war = War.new
+      expect(war).to respond_to(:massive_attack?)
+      expect(war).to respond_to(:massive_attack=)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.datetime :activated_at
   end
+
+  create_table :wars, force: true do |t|
+    t.datetime :massive_attack_at
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Was broken for properties that contained `_at` inside the property, such as `massive_attack_at`.
