### PR TITLE
Add scope for easily searching boolean timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ puts post.published_at
 #=> nil
 ```
 
+This also adds a scope for each timestamps column
+
+```ruby
+Post.published
+#=> [#<Post published_at: Fri, 04 Sep 2020 18:16:38 UTC +00:00>]
+
+Post.published(false)
+#=> [#<Post published_at: nil>]
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/boolean_timestamps.rb
+++ b/lib/boolean_timestamps.rb
@@ -22,6 +22,13 @@ module BooleanTimestamps
             send("#{timestamp_attribute}=", timestamp)
           end
         end
+        scope boolean_attribute, lambda { |value = true|
+          if value
+            where.not(timestamp_attribute => nil)
+          else
+            where(timestamp_attribute => nil)
+          end
+        }
       end
     end
   end

--- a/spec/boolean_timestamps_spec.rb
+++ b/spec/boolean_timestamps_spec.rb
@@ -38,5 +38,10 @@ describe BooleanTimestamps do
       expect(war).to respond_to(:massive_attack?)
       expect(war).to respond_to(:massive_attack=)
     end
+    it 'adds a scope for the timestamp' do
+      expect(User.activated.to_sql).to include('activated_at" IS NOT NULL')
+      expect(User.activated(true).to_sql).to include('activated_at" IS NOT NULL')
+      expect(User.activated(false).to_sql).to include('activated_at" IS NULL')
+    end
   end
 end


### PR DESCRIPTION
This is a pattern we use a lot a BetterUp, and I'm proposing we add it as a first class feature of this library.

Example:

```ruby
class User < ActiveRecord::Base
  boolean_timestamps :activated_at
end

# Now let's find all Users that have been activated

User.activated_at
# User Load  SELECT "users".* FROM "users" WHERE "users"."activated_at" IS NOT NULL

# What about Users that have not been activated yet?

User.activated_at(false)
# User Load  SELECT "users".* FROM "users" WHERE "users"."activated_at" IS NULL
```

Nice right?