### PR TITLE
Add option to skip generating scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ class Post < ActiveRecord::Base
 end
 ```
 
+### Option: Generated scope
+
+By default, this adds a scope for each timestamp column:
+
+```ruby
+Post.published
+#=> [#<Post published_at: Fri, 04 Sep 2020 18:16:38 UTC +00:00>]
+
+Post.published(false)
+#=> [#<Post published_at: nil>]
+```
+
+To skip defining the scope, set the `:scopes` option to `false` when calling `boolean_timestamps`.
+
+```ruby
+class Post < ActiveRecord::Base
+  boolean_timestamps :published_at, scopes: false
+end
+```
+```ruby
+Post.respond_to?(:published)
+#=> false
+```
+
+
 ## Example
 
 ```ruby
@@ -33,17 +58,6 @@ post.update!(published: false)
 puts post.published_at
 #=> nil
 ```
-
-This also adds a scope for each timestamps column
-
-```ruby
-Post.published
-#=> [#<Post published_at: Fri, 04 Sep 2020 18:16:38 UTC +00:00>]
-
-Post.published(false)
-#=> [#<Post published_at: nil>]
-```
-
 
 ## Development
 

--- a/lib/boolean_timestamps.rb
+++ b/lib/boolean_timestamps.rb
@@ -6,7 +6,7 @@ module BooleanTimestamps
   extend ActiveSupport::Concern
 
   class_methods do
-    def boolean_timestamps(*attributes)
+    def boolean_timestamps(*attributes, scopes: true)
       attributes.each do |timestamp_attribute|
         boolean_attribute = timestamp_attribute.to_s.gsub(/_at\z/, '')
         define_method boolean_attribute do
@@ -22,13 +22,15 @@ module BooleanTimestamps
             send("#{timestamp_attribute}=", timestamp)
           end
         end
-        scope boolean_attribute, lambda { |value = true|
-          if value
-            where.not(timestamp_attribute => nil)
-          else
-            where(timestamp_attribute => nil)
-          end
-        }
+        if scopes
+          scope boolean_attribute, lambda { |value = true|
+            if value
+              where.not(timestamp_attribute => nil)
+            else
+              where(timestamp_attribute => nil)
+            end
+          }
+        end
       end
     end
   end

--- a/spec/boolean_timestamps_spec.rb
+++ b/spec/boolean_timestamps_spec.rb
@@ -5,6 +5,10 @@ describe BooleanTimestamps do
     boolean_timestamps :activated_at
   end
 
+  class UserWithoutScopes < ActiveRecord::Base
+    boolean_timestamps :activated_at, scopes: false
+  end
+
   class War < ActiveRecord::Base
     boolean_timestamps :massive_attack_at
   end
@@ -42,6 +46,9 @@ describe BooleanTimestamps do
       expect(User.activated.to_sql).to include('activated_at" IS NOT NULL')
       expect(User.activated(true).to_sql).to include('activated_at" IS NOT NULL')
       expect(User.activated(false).to_sql).to include('activated_at" IS NULL')
+    end
+    it 'does not add a scope when scopes option is false' do
+      expect(UserWithoutScopes.respond_to?(:activated)).to be false
     end
   end
 end


### PR DESCRIPTION
This adds a `:scopes` option to `boolean_timestamps` that allows the user to skip generating the scope. This may be desirable in particular when the generated scope conflicts with an existing Rails method.

For example, `boolean_timestamps :loaded_at` attempts to create a scope `:loaded` and raises an error because the method `:loaded` is already defined. Adding the `scopes: false` option avoids the error.

Fixes #7